### PR TITLE
Fixed typo in name

### DIFF
--- a/src/epub/text/bingo-and-the-little-woman.xhtml
+++ b/src/epub/text/bingo-and-the-little-woman.xhtml
@@ -167,7 +167,7 @@
 			<p>While I was prowling about the room waiting for him to show up, I suddenly caught sight of that bally <i epub:type="se:name.publicaton.book">Woman Who Braved All</i> lying on one of the tables. It was open at page two hundred and fifteen, and a passage heavily marked in pencil caught my eye. And directly I read it I saw that it was all to the mustard and was going to help me in my business.</p>
 			<p>This was the passage:</p>
 			<blockquote>
-				<p>“What can prevail”⁠—Millicent’s eyes flashed as she faced the stern old man⁠—“what can prevail against a pure and all-consuming love? Neither principalities nor powers, my lord, nor all the puny prohibitions of guardians and parents. I love your son, Lord Mindermere, and nothing can keep us apart. Since time first began this love of ours was fated, and who are you to pit yourself against the decrees of Fate?”</p>
+				<p>“What can prevail”⁠—Millicent’s eyes flashed as she faced the stern old man⁠—“what can prevail against a pure and all-consuming love? Neither principalities nor powers, my lord, nor all the puny prohibitions of guardians and parents. I love your son, Lord Windermere, and nothing can keep us apart. Since time first began this love of ours was fated, and who are you to pit yourself against the decrees of Fate?”</p>
 				<p>The earl looked at her keenly from beneath his bushy eyebrows.</p>
 				<p>“Humph!” he said.</p>
 			</blockquote>


### PR DESCRIPTION
Mindermere -> Windermere. It is correctly "Windermere" on line 197. I double-checked the Internet Archive scan of The Inimitable Jeeves (p242) where it is also "Windermere".